### PR TITLE
Add English comments to services and controllers

### DIFF
--- a/src/main/java/com/chillmo/skatedb/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chillmo/skatedb/security/JwtAuthenticationFilter.java
@@ -33,8 +33,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        // Skip filtering for public endpoints
         return EXCLUDE.contains(request.getServletPath());
     }
+    /**
+     * Create a new JWT authentication filter.
+     */
     public JwtAuthenticationFilter(JwtUtils jwtUtils) {
         this.jwtUtils = jwtUtils;
     }
@@ -44,7 +48,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
         String path = request.getRequestURI();
-        // überspringe, wenn es einer der Public-Pfade ist
+        // Skip processing if request is one of the public paths
         if (EXCLUDE.contains(path)) {
             chain.doFilter(request, response);
             return;

--- a/src/main/java/com/chillmo/skatedb/security/SecurityConfig.java
+++ b/src/main/java/com/chillmo/skatedb/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(userDetailsService);
         provider.setPasswordEncoder(passwordEncoder);
-        // important: show user not found exceptions
+        // Show "user not found" exceptions instead of hiding them
         provider.setHideUserNotFoundExceptions(false);
         return provider;
     }
@@ -55,6 +55,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/login", "/api/register", "/api/token/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                // Insert our JWT filter before username/password authentication
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         ;
         return http.build();

--- a/src/main/java/com/chillmo/skatedb/trick/library/controller/TrickLibraryController.java
+++ b/src/main/java/com/chillmo/skatedb/trick/library/controller/TrickLibraryController.java
@@ -21,31 +21,56 @@ public class TrickLibraryController {
         this.trickImportService = trickImportService;
     }
 
+    /**
+     * Trigger the import of tricks from a CSV file.
+     *
+     * @param filePath location of the CSV file
+     * @return status message of the import
+     */
     @PostMapping("/import")
     public String importTricks(@RequestParam String filePath) {
         trickImportService.importTricksFromCsv(filePath);
-        return "Import abgeschlossen!";
+        return "Import finished";
     }
-    // Hinzufügen eines neuen Tricks
+
+    /**
+     * Add a new trick to the library.
+     *
+     * @param trick trick to persist
+     * @return the saved trick entity
+     */
     @PostMapping
     public ResponseEntity<Trick> addTrick(@RequestBody Trick trick) {
         Trick savedTrick = trickLibraryService.addTrick(trick);
         return ResponseEntity.ok(savedTrick);
     }
 
-    // Abrufen eines einzelnen Tricks nach ID
+    /**
+     * Retrieve a single trick by its id.
+     *
+     * @param id identifier of the trick
+     * @return trick with the given id
+     */
     @GetMapping("/{id}")
     public ResponseEntity<Trick> getTrickById(@PathVariable Long id) {
         return ResponseEntity.ok(trickLibraryService.getTrickById(id));
     }
 
-    // Liste aller Tricks abrufen
+    /**
+     * Get a list of all tricks in the library.
+     */
     @GetMapping
     public ResponseEntity<List<Trick>> getAllTricks() {
         return ResponseEntity.ok(trickLibraryService.getAllTricks());
     }
 
-    // Suchen von Tricks nach Namen und Schwierigkeitsgrad
+    /**
+     * Search for tricks by name and difficulty.
+     *
+     * @param name optional name filter
+     * @param difficulty optional difficulty filter
+     * @return list of matching tricks
+     */
     @GetMapping("/search")
     public ResponseEntity<List<Trick>> searchTricks(
             @RequestParam(required = false) String name,

--- a/src/main/java/com/chillmo/skatedb/trick/library/service/TrickImportService.java
+++ b/src/main/java/com/chillmo/skatedb/trick/library/service/TrickImportService.java
@@ -23,10 +23,17 @@ public class TrickImportService {
         this.trickLibraryRepository = trickLibraryRepository;
     }
 
+    /**
+     * Import tricks from the given CSV file and persist them in the library.
+     * Existing tricks will be ignored.
+     *
+     * @param filePath path to the CSV file containing trick data
+     */
     public void importTricksFromCsv(String filePath) {
         try (CSVReader reader = new CSVReader(new FileReader(filePath))) {
             String[] line;
-            reader.readNext(); // Überspringe die Kopfzeile
+            // Skip the header row
+            reader.readNext();
 
             int lineNumber = 1;
             while ((line = reader.readNext()) != null) {
@@ -38,7 +45,7 @@ public class TrickImportService {
                 }
 
                 try {
-                    // CSV-Spalten:
+                    // CSV columns:
                     // 0: name
                     // 1: description
                     // 2: difficulty
@@ -46,7 +53,7 @@ public class TrickImportService {
                     // 4: category
                     // 5: imageUrl
                     // 6: videoUrl
-                    // 7: prerequisites (Trick-Namen, durch Semikolon getrennt)
+                    // 7: prerequisites (trick names separated by semicolon)
                     String name = line[0];
                     String description = line[1];
                     String difficultyStr = line[2];
@@ -56,13 +63,13 @@ public class TrickImportService {
                     String videoUrl = line[6];
                     String prerequisitesStr = line[7];
 
-                    // Enum-Typen anhand der Strings bestimmen
+                    // Determine enum values from the provided strings
                     Difficulty difficulty = Difficulty.valueOf(difficultyStr.toUpperCase());
                     TrickType trickType = TrickType.valueOf(trickTypeStr.toUpperCase());
 
-                    // Prüfen, ob der Trick bereits existiert
+                    // Check if the trick already exists
                     if (trickLibraryRepository.findByNameContaining(name).isEmpty()) {
-                        // Neuen Trick ohne Voraussetzungen erstellen
+                        // Create the new trick without prerequisites
                         Trick trick = Trick.builder()
                                 .name(name)
                                 .description(description)
@@ -73,13 +80,13 @@ public class TrickImportService {
                                 .videoUrl(videoUrl)
                                 .build();
 
-                        // Falls prerequisites angegeben wurden, diese parsen und zuordnen
+                        // Parse and assign prerequisites if provided
                         if (prerequisitesStr != null && !prerequisitesStr.trim().isEmpty()) {
                             String[] prerequisiteNames = prerequisitesStr.split(";");
                             List<Trick> prerequisitesList = new ArrayList<>();
                             for (String prereqName : prerequisiteNames) {
                                 prereqName = prereqName.trim();
-                                // Sucht nach einem Trick, dessen Name den angegebenen String enthält.
+                                // Look up a trick whose name contains the given string
                                 List<Trick> prereqTricks = trickLibraryRepository.findByNameContaining(prereqName);
                                 if (!prereqTricks.isEmpty()) {
                                     prerequisitesList.add(prereqTricks.get(0));

--- a/src/main/java/com/chillmo/skatedb/trick/library/service/TrickLibraryService.java
+++ b/src/main/java/com/chillmo/skatedb/trick/library/service/TrickLibraryService.java
@@ -5,11 +5,36 @@ import com.chillmo.skatedb.trick.domain.Trick;
 import java.util.List;
 
 public interface TrickLibraryService {
+
+    /**
+     * Persist a new trick in the library.
+     *
+     * @param trick trick to add
+     * @return the saved trick entity
+     */
     Trick addTrick(Trick trick);
 
+    /**
+     * Retrieve a trick by its id.
+     *
+     * @param id identifier of the trick
+     * @return the found trick
+     */
     Trick getTrickById(Long id);
 
+    /**
+     * Get all tricks stored in the library.
+     *
+     * @return list of all tricks
+     */
     List<Trick> getAllTricks();
 
+    /**
+     * Search for tricks optionally filtered by name and difficulty.
+     *
+     * @param name optional partial name
+     * @param difficulty optional difficulty level
+     * @return list of matching tricks
+     */
     List<Trick> searchTricks(String name, String difficulty);
 }

--- a/src/main/java/com/chillmo/skatedb/trick/library/service/TrickLibraryServiceImpl.java
+++ b/src/main/java/com/chillmo/skatedb/trick/library/service/TrickLibraryServiceImpl.java
@@ -16,22 +16,34 @@ public class TrickLibraryServiceImpl implements TrickLibraryService {
     }
 
     @Override
+    /**
+     * {@inheritDoc}
+     */
     public Trick addTrick(Trick trick) {
         return trickLibraryRepository.save(trick);
     }
 
     @Override
+    /**
+     * {@inheritDoc}
+     */
     public Trick getTrickById(Long id) {
         return trickLibraryRepository.findById(id).orElseThrow(() ->
-                new IllegalArgumentException("Trick mit ID " + id + " nicht gefunden."));
+                new IllegalArgumentException("Trick with ID " + id + " not found."));
     }
 
     @Override
+    /**
+     * {@inheritDoc}
+     */
     public List<Trick> getAllTricks() {
         return trickLibraryRepository.findAll();
     }
 
     @Override
+    /**
+     * {@inheritDoc}
+     */
     public List<Trick> searchTricks(String name, String difficulty) {
         if (name != null && difficulty != null) {
             return trickLibraryRepository.findByNameContainingAndDifficulty(name, difficulty);

--- a/src/main/java/com/chillmo/skatedb/user/authentication/controller/AuthController.java
+++ b/src/main/java/com/chillmo/skatedb/user/authentication/controller/AuthController.java
@@ -30,6 +30,12 @@ public class AuthController {
     }
 
     @PostMapping("/login")
+    /**
+     * Authenticate a user and return a JWT token.
+     *
+     * @param req login credentials
+     * @return JWT token if authentication succeeds
+     */
     public ResponseEntity<JwtResponseDto> login(@Valid @RequestBody LoginRequestDto req) {
         Authentication auth = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(req.getIdentifier(), req.getPassword())

--- a/src/main/java/com/chillmo/skatedb/user/email/controller/EmailController.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/controller/EmailController.java
@@ -16,9 +16,9 @@ public class EmailController {
     }
 
     /**
-     * Test-Endpoint: Sendet an die angegebene Adresse eine einfache "Guten Tag"-Mail.
+     * Test endpoint to send a simple "hello" mail to the provided address.
      * POST /api/email/test
-     * Body: { "email": "adresse@beispiel.de" }
+     * Body: { "email": "address@example.com" }
      */
     @PostMapping("/test")
     public ResponseEntity<String> sendTestEmail(@RequestBody EmailRequestDto request) {
@@ -29,8 +29,7 @@ public class EmailController {
         return ResponseEntity.ok("Test-Mail an " + to + " versendet.");
     }
     /**
-     * todo: creating conformation email. To Confirm the registration of a new @User.
-     *
+     * TODO: Create confirmation e-mail to verify new user registrations.
      */
 
 

--- a/src/main/java/com/chillmo/skatedb/user/email/service/EmailService.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/service/EmailService.java
@@ -3,13 +3,16 @@ package com.chillmo.skatedb.user.email.service;
 
 public interface EmailService {
     /**
-     * Versendet eine HTML-E-Mail an die angegebene Adresse.
+     * Send an HTML e-mail to the given address.
      *
-     * @param to      Empfänger-Adresse
-     * @param subject Betreff
-     * @param body    HTML-Inhalt der Mail
+     * @param to      recipient address
+     * @param subject mail subject
+     * @param body    HTML body of the mail
      */
     void send(String to, String subject, String body);
 
-    void sendAsync(String email, String s, String body);
+    /**
+     * Send the e-mail asynchronously using the configured executor.
+     */
+    void sendAsync(String email, String subject, String body);
 }

--- a/src/main/java/com/chillmo/skatedb/user/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/service/EmailServiceImpl.java
@@ -25,6 +25,9 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
+    /**
+     * {@inheritDoc}
+     */
     public void send(String to, String subject, String body) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
@@ -39,12 +42,15 @@ public class EmailServiceImpl implements EmailService {
         } catch (MessagingException e) {
             logger.error("Error sending email to: {}", to, e);
             throw new IllegalStateException(
-                    "Fehler beim Versand der E-Mail an „" + to + "“", e);
+                    "Error sending e-mail to " + to, e);
         }
     }
 
     @Async
     @Override
+    /**
+     * {@inheritDoc}
+     */
     public void sendAsync(String to, String subject, String body) {
         send(to, subject, body);
     }

--- a/src/main/java/com/chillmo/skatedb/user/registration/controller/ConfirmationController.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/controller/ConfirmationController.java
@@ -13,6 +13,12 @@ public class ConfirmationController {
     public ConfirmationController(ConfirmationTokenService svc) { this.confirmationTokenService = svc; }
 
     @GetMapping("/confirm")
+    /**
+     * Confirm a registration token.
+     *
+     * @param token token to verify
+     * @return confirmation message
+     */
     public ResponseEntity<ConfirmationResponse> confirm(@RequestParam String token) {
         confirmationTokenService.confirmToken(token);
         return ResponseEntity.ok(new ConfirmationResponse("Account verified"));
@@ -22,6 +28,12 @@ public class ConfirmationController {
     }
 
     @PostMapping("/renew")
+    /**
+     * Renew an expired confirmation token.
+     *
+     * @param expiredToken token that has expired
+     * @return new token with new expiration date
+     */
     public ResponseEntity<ConfirmationTokenResponseDto> renewToken(@RequestParam("token") String expiredToken) {
         var dto = confirmationTokenService.renewToken(expiredToken);
         return ResponseEntity.ok(dto);

--- a/src/main/java/com/chillmo/skatedb/user/registration/controller/UserRegistrationController.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/controller/UserRegistrationController.java
@@ -24,6 +24,12 @@ public class UserRegistrationController {
     }
 
     @PostMapping()
+    /**
+     * Register a new user account.
+     *
+     * @param registrationDto user registration data
+     * @return the created user
+     */
     public ResponseEntity<?> registerUser(@Valid @RequestBody UserRegistrationDto registrationDto) {
         User createdUser = userRegistrationService.registerUser(registrationDto);
         return new ResponseEntity<>(createdUser, HttpStatus.CREATED);

--- a/src/main/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenRepository.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenRepository.java
@@ -7,5 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ConfirmationTokenRepository extends JpaRepository<ConfirmationToken, Long> {
+
+    /**
+     * Find a confirmation token by its string value.
+     *
+     * @param token token value
+     * @return optional token entity
+     */
     Optional<ConfirmationToken> findByToken(String token);
 }

--- a/src/main/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenService.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenService.java
@@ -27,6 +27,12 @@ public class ConfirmationTokenService {
     }
 
 
+    /**
+     * Create and persist a new confirmation token for the given user.
+     *
+     * @param user user to generate the token for
+     * @return the created confirmation token
+     */
     public ConfirmationToken getNewConfirmationToken(User user) {
 
 
@@ -42,6 +48,11 @@ public class ConfirmationTokenService {
         return confirmationToken;
     }
 
+    /**
+     * Validate that the given token is not expired.
+     *
+     * @param confirmationToken token to check
+     */
     public void tokenExpired(ConfirmationToken confirmationToken) {
         if (confirmationToken.getExpiresAt().isBefore(LocalDateTime.now())) {
             throw new TokenExpiredException(confirmationToken.getToken());
@@ -76,14 +87,14 @@ public class ConfirmationTokenService {
     }
 
     /**
-     * Bestätigt einen Registrierungs-Token:
-     * - wirft TokenNotFoundException, wenn der Token nicht existiert
-     * - wirft TokenExpiredException, wenn er abgelaufen ist
-     * - setzt user.enabled = true und speichert den User
-     * - entfernt den Token
+     * Confirm a registration token.
+     * <p>
+     * Throws {@link TokenNotFoundException} if the token does not exist and
+     * {@link TokenExpiredException} if it is expired. On success the user is
+     * enabled and the token removed.
      *
-     * @param token der Bestätigungs-Token
-     * @return true, wenn die Bestätigung erfolgreich war
+     * @param token token to confirm
+     * @return {@code true} if confirmation succeeded
      */
     public boolean confirmToken(String token) {
         var confirmationToken = tokenRepository.findByToken(token)

--- a/src/main/java/com/chillmo/skatedb/user/registration/service/PasswordValidationService.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/service/PasswordValidationService.java
@@ -21,6 +21,13 @@ public class PasswordValidationService {
             );
         }
     }
+
+    /**
+     * Check if the given password satisfies the policy without throwing.
+     *
+     * @param password password to check
+     * @return true if valid according to the policy
+     */
     public boolean isValid(String password) {
         return password != null && PASSWORD_PATTERN.matcher(password).matches();
     }


### PR DESCRIPTION
## Summary
- add English Javadoc style comments across multiple services and controllers
- translate existing comments in `JwtUtils` and `JwtAuthenticationFilter`
- clarify SecurityConfig and Email related services

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be2648cec83309038a5b040418036