### PR TITLE
Update README install instructions

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -46,3 +46,24 @@
    ```bash
    git clone https://github.com/yourusername/SkateDB.git
    cd SkateDB
+   ```
+
+2. **Build the project**:
+   ```bash
+   ./mvnw clean package
+   ```
+
+3. **Run the application**:
+   ```bash
+   ./mvnw spring-boot:run
+   ```
+
+   The application will start on `http://localhost:8080` by default.
+
+4. **Configuration**:
+   Create a `.env` file in `src/main/resources` or set these variables in your environment:
+   ```bash
+   jwt.secret=change_me
+   jwt.expirationMs=3600000
+   spring.mail.username=you@example.com
+   ```


### PR DESCRIPTION
## Summary
- fix truncated install section in the README
- document how to build and run the project
- add note about required environment variables

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685be7f8c82c833086616cfc7e4c85b7