### PR TITLE
Add admin user and enable endpoint

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -70,10 +70,11 @@
 
 ## Template Users
 
-When the application starts, three example users are created automatically. You can use these accounts to log in immediately.
+When the application starts, four example users are created automatically. You can use these accounts to log in immediately.
 
 | Username | Email | Password | Mastered Tricks |
 |-----------|-----------------|-------------|----------------------------------|
+| admin | admin@example.com | adminpass | |
 | tonyhawk | tony@example.com | password123 | Kickflip, Laser Flip, Ollie |
 | janedoe | jane@example.com | password123 | Heelflip, Shove-it, Ollie |
 | bobsmith | bob@example.com | password123 | Ollie |

--- a/src/main/java/com/chillmo/skatedb/user/TemplateUserDataLoader.java
+++ b/src/main/java/com/chillmo/skatedb/user/TemplateUserDataLoader.java
@@ -49,6 +49,14 @@ public class TemplateUserDataLoader implements CommandLineRunner {
     public void run(String... args) {
         List<TemplateUser> templates = List.of(
                 new TemplateUser(
+                        "admin",
+                        "admin@example.com",
+                        "adminpass",
+                        ExperienceLevel.PRO,
+                        Stand.Regular,
+                        List.of()
+                ),
+                new TemplateUser(
                         "tonyhawk",
                         "tony@example.com",
                         "password123",
@@ -85,7 +93,9 @@ public class TemplateUserDataLoader implements CommandLineRunner {
                     .experienceLevel(t.level())
                     .stand(t.stand())
                     .enabled(true)
-                    .roles(Set.of(Role.ROLE_USER))
+                    .roles(t.username().equals("admin") ?
+                            Set.of(Role.ROLE_USER, Role.ROLE_ADMIN) :
+                            Set.of(Role.ROLE_USER))
                     .build();
             User savedUser = userRepository.save(user);
 

--- a/src/main/java/com/chillmo/skatedb/user/controller/UserController.java
+++ b/src/main/java/com/chillmo/skatedb/user/controller/UserController.java
@@ -3,9 +3,8 @@ package com.chillmo.skatedb.user.controller;
 import com.chillmo.skatedb.user.domain.User;
 import com.chillmo.skatedb.user.service.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,5 +26,15 @@ public class UserController {
     @GetMapping
     public ResponseEntity<List<User>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    /**
+     * Enable a user by id. Only admins may perform this action.
+     */
+    @PutMapping("/{id}/enable")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<Void> enableUser(@PathVariable Long id) {
+        userService.enableUser(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/chillmo/skatedb/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/chillmo/skatedb/user/exception/UserExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.chillmo.skatedb.user.exception;
+
+import com.chillmo.skatedb.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class UserExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
+        ErrorResponse err = new ErrorResponse(
+                ex.getMessage(),
+                HttpStatus.NOT_FOUND.value(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(err);
+    }
+}

--- a/src/main/java/com/chillmo/skatedb/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/chillmo/skatedb/user/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.chillmo.skatedb.user.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(Long id) {
+        super("User not found: " + id);
+    }
+}

--- a/src/main/java/com/chillmo/skatedb/user/service/UserService.java
+++ b/src/main/java/com/chillmo/skatedb/user/service/UserService.java
@@ -42,4 +42,18 @@ public class UserService {
     public java.util.List<User> getAllUsers() {
         return userRepository.findAll();
     }
+
+    /**
+     * Enable a user account by id.
+     *
+     * @param id user id
+     * @return the updated user
+     */
+    @org.springframework.transaction.annotation.Transactional
+    public User enableUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new com.chillmo.skatedb.user.exception.UserNotFoundException(id));
+        user.setEnabled(true);
+        return userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## Summary
- add admin template user
- expose admin-protected endpoint to enable a user
- record user enabling logic in service
- provide exception and handler for missing users
- document new admin user in README

## Testing
- `./mvnw -q test` *(fails: Could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bfe5bd4bc8330961ed9348fbaabbf