### PR TITLE
Refine global exception handling

### DIFF
--- a/src/main/java/com/chillmo/skatedb/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chillmo/skatedb/exception/GlobalExceptionHandler.java
@@ -3,12 +3,10 @@ package com.chillmo.skatedb.exception;
 import com.chillmo.skatedb.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -16,21 +14,31 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handleUserAlreadyExistsException(UserAlreadyExistsException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
+    }
 
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(String message, HttpStatus status) {
         ErrorResponse err = new ErrorResponse(
-                ex.getMessage(),
-                HttpStatus.CONFLICT.value(),
+                message,
+                status.value(),
                 LocalDateTime.now()
         );
 
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(err);
+        return ResponseEntity.status(status).body(err);
     }
-    @ExceptionHandler(InvalidCredentialsException.class)
-    public ResponseEntity<String> handleInvalidCredentials(InvalidCredentialsException ex) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
-    }
-
-
-
-    // Add more exception handlers as needed
 }


### PR DESCRIPTION
## Summary
- update the invalid credential handler to return a structured `ErrorResponse`
- add runtime and illegal state handlers that map to consistent `ErrorResponse` payloads
- centralize error response construction and remove the placeholder comment

## Testing
- `./mvnw test` *(fails: unable to download Maven distribution because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fec660048330b7824e0963ada3ff