### PR TITLE
Add user trick retrieval and update endpoints

### DIFF
--- a/src/main/java/com/chillmo/skatedb/trick_user/UpdateTrickStatusRequestDto.java
+++ b/src/main/java/com/chillmo/skatedb/trick_user/UpdateTrickStatusRequestDto.java
@@ -1,0 +1,8 @@
+package com.chillmo.skatedb.trick_user;
+
+import lombok.Data;
+
+@Data
+public class UpdateTrickStatusRequestDto {
+    private TrickStatus status;
+}

--- a/src/main/java/com/chillmo/skatedb/trick_user/UserTrickController.java
+++ b/src/main/java/com/chillmo/skatedb/trick_user/UserTrickController.java
@@ -6,10 +6,15 @@ import com.chillmo.skatedb.trick.library.repository.TrickLibraryRepository;
 import com.chillmo.skatedb.user.domain.User;
 import com.chillmo.skatedb.user.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/user-tricks")
@@ -43,5 +48,21 @@ public class UserTrickController {
         UserTrick userTrick = userTrickService.startTrick(user, trick);
 
         return ResponseEntity.ok(userTrick);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<UserTrick>> getUserTricks(@PathVariable Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+
+        List<UserTrick> userTricks = userTrickService.getUserTricks(userId);
+        return ResponseEntity.ok(userTricks);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserTrick> updateTrickStatus(@PathVariable Long id,
+                                                       @RequestBody UpdateTrickStatusRequestDto dto) {
+        UserTrick updatedUserTrick = userTrickService.updateTrickStatus(id, dto.getStatus());
+        return ResponseEntity.ok(updatedUserTrick);
     }
 }

--- a/src/main/java/com/chillmo/skatedb/trick_user/UserTrickRepository.java
+++ b/src/main/java/com/chillmo/skatedb/trick_user/UserTrickRepository.java
@@ -12,4 +12,6 @@ public interface UserTrickRepository extends JpaRepository<UserTrick, Long> {
     Optional<UserTrick> findByUserAndTrick(User user, Trick trick);
 
     List<UserTrick> findByUser(User user);
+
+    List<UserTrick> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/chillmo/skatedb/trick_user/UserTrickService.java
+++ b/src/main/java/com/chillmo/skatedb/trick_user/UserTrickService.java
@@ -6,6 +6,7 @@ import com.chillmo.skatedb.user.domain.User;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -37,5 +38,22 @@ public class UserTrickService {
                 .status(TrickStatus.IN_PROGRESS)
                 .build();
         return userTrickRepository.save(newEntry);
+    }
+
+    public List<UserTrick> getUserTricks(Long userId) {
+        return userTrickRepository.findAllByUserId(userId);
+    }
+
+    public UserTrick updateTrickStatus(Long id, TrickStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("TrickStatus must not be null");
+        }
+
+        UserTrick userTrick = userTrickRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("UserTrick not found with id: " + id));
+
+        userTrick.setStatus(status);
+
+        return userTrickRepository.save(userTrick);
     }
 }


### PR DESCRIPTION
## Summary
- add a GET endpoint to retrieve a user's trick statuses
- add a PUT endpoint to update a user's trick status
- extend the user trick service and repository to support the new operations

## Testing
- ./mvnw test *(fails: wrapper could not download Maven distribution in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c903155ab483308c4cef4e3f2fecd1