### PR TITLE
Add email confirmation endpoint

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,6 +25,7 @@ This document lists the available REST endpoints provided by the SkateDB applica
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | `POST` | `/api/email/test` | Send a simple test email. |
+| `POST` | `/api/email/confirm` | Send an email containing a confirmation link for a token. |
 
 ### Trick Library
 

--- a/src/main/java/com/chillmo/skatedb/user/email/controller/EmailController.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/controller/EmailController.java
@@ -1,5 +1,6 @@
 package com.chillmo.skatedb.user.email.controller;
 
+import com.chillmo.skatedb.user.email.dto.EmailConfirmationRequestDto;
 import com.chillmo.skatedb.user.email.dto.EmailRequestDto;
 import com.chillmo.skatedb.user.email.service.EmailService;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +30,25 @@ public class EmailController {
         return ResponseEntity.ok("Test-Mail an " + to + " versendet.");
     }
     /**
-     * TODO: Create confirmation e-mail to verify new user registrations.
+     * Send a confirmation e-mail containing a verification link.
+     * POST /api/email/confirm
+     * Body: { "email": "address@example.com", "token": "confirmation-token" }
      */
+    @PostMapping("/confirm")
+    public ResponseEntity<String> sendConfirmationEmail(@RequestBody EmailConfirmationRequestDto request) {
+        String to = request.getEmail();
+        String token = request.getToken();
+
+        String confirmationLink = "/api/token/confirm?token=" + token;
+        String subject = "Bitte bestätige deine E-Mail-Adresse";
+        String body = "<p>Hallo,</p>" +
+                "<p>bitte bestätige deine E-Mail-Adresse, indem du auf den folgenden Link klickst:</p>" +
+                "<a href=\"" + confirmationLink + "\">E-Mail bestätigen</a>";
+
+        emailService.sendAsync(to, subject, body);
+
+        return ResponseEntity.ok("Bestätigungsmail an " + to + " versendet.");
+    }
 
 
 }

--- a/src/main/java/com/chillmo/skatedb/user/email/dto/EmailConfirmationRequestDto.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/dto/EmailConfirmationRequestDto.java
@@ -1,0 +1,9 @@
+package com.chillmo.skatedb.user.email.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailConfirmationRequestDto {
+    private String email;
+    private String token;
+}


### PR DESCRIPTION
## Summary
- add a DTO for confirmation e-mail requests with recipient and token
- implement `/api/email/confirm` endpoint to dispatch confirmation e-mails asynchronously
- document the new endpoint in the API reference

## Testing
- `./mvnw -q test` *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21c16af483309d2a1461a2782aee