### PR TITLE
Add user profile management endpoints

### DIFF
--- a/src/main/java/com/chillmo/skatedb/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chillmo/skatedb/security/JwtAuthenticationFilter.java
@@ -25,6 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final List<String> EXCLUDE = List.of(
             "/api/register",
+            "/api/auth/login",
             "/api/login",
             "/api/email/test",
             "/api/token/confirm",

--- a/src/main/java/com/chillmo/skatedb/security/SecurityConfig.java
+++ b/src/main/java/com/chillmo/skatedb/security/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.chillmo.skatedb.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -53,9 +52,9 @@ public class SecurityConfig {
                         // Allow /error dispatch
                         .requestMatchers("/error", "/error/**").permitAll()
                         .requestMatchers("/api/auth/**", "/h2-console/**").permitAll()
-                        .requestMatchers("/api/login", "/api/register", "/api/token/**", "/api/users/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/users/**").permitAll()
-                        .requestMatchers(HttpMethod.PUT, "/api/users/**").permitAll()
+                        .requestMatchers("/api/register", "/api/token/**").permitAll()
+                        .requestMatchers("/api/users/me/**").authenticated()
+                        .requestMatchers("/api/users/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 // Insert our JWT filter before username/password authentication

--- a/src/main/java/com/chillmo/skatedb/user/controller/UserController.java
+++ b/src/main/java/com/chillmo/skatedb/user/controller/UserController.java
@@ -1,8 +1,15 @@
 package com.chillmo.skatedb.user.controller;
 
 import com.chillmo.skatedb.user.domain.User;
+import com.chillmo.skatedb.user.dto.ChangePasswordRequest;
+import com.chillmo.skatedb.user.dto.UpdateProfileRequest;
+import com.chillmo.skatedb.user.dto.UpdateUserRolesRequest;
+import com.chillmo.skatedb.user.dto.UserProfileResponse;
 import com.chillmo.skatedb.user.service.UserService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,17 +30,59 @@ public class UserController {
      * @return list of users
      */
     @GetMapping
-    public ResponseEntity<List<User>> getAllUsers() {
-        return ResponseEntity.ok(userService.getAllUsers());
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<UserProfileResponse>> getAllUsers() {
+        List<UserProfileResponse> users = userService.getAllUsers().stream()
+                .map(UserProfileResponse::from)
+                .toList();
+        return ResponseEntity.ok(users);
     }
 
     /**
      * Enable a user by id. Only admins may perform this action.
      */
     @PutMapping("/{id}/enable")
-    //@PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> enableUser(@PathVariable Long id) {
         userService.enableUser(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<UserProfileResponse> getCurrentUser(Authentication authentication) {
+        User user = userService.getByUsername(authentication.getName());
+        return ResponseEntity.ok(UserProfileResponse.from(user));
+    }
+
+    @PutMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<UserProfileResponse> updateProfile(@RequestBody @Valid UpdateProfileRequest request,
+                                                             Authentication authentication) {
+        User updated = userService.updateProfile(authentication.getName(), request);
+        return ResponseEntity.ok(UserProfileResponse.from(updated));
+    }
+
+    @PutMapping("/me/password")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> changePassword(@RequestBody @Valid ChangePasswordRequest request,
+                                               Authentication authentication) {
+        userService.changePassword(authentication.getName(), request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteAccount(Authentication authentication) {
+        userService.deleteAccount(authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{id}/roles")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserProfileResponse> updateUserRoles(@PathVariable Long id,
+                                                               @RequestBody @Valid UpdateUserRolesRequest request) {
+        User user = userService.updateUserRoles(id, request);
+        return ResponseEntity.ok(UserProfileResponse.from(user));
     }
 }

--- a/src/main/java/com/chillmo/skatedb/user/domain/CustomUserDetails.java
+++ b/src/main/java/com/chillmo/skatedb/user/domain/CustomUserDetails.java
@@ -20,7 +20,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public Set<? extends GrantedAuthority> getAuthorities() {
         return user.getRoles().stream()
-                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+                .map(role -> new SimpleGrantedAuthority(role.name()))
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/com/chillmo/skatedb/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/chillmo/skatedb/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,19 @@
+package com.chillmo.skatedb.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Request payload for updating the password of the currently authenticated user.
+ */
+@Data
+public class ChangePasswordRequest {
+
+    @NotBlank
+    private String currentPassword;
+
+    @NotBlank
+    @Size(min = 8, max = 100)
+    private String newPassword;
+}

--- a/src/main/java/com/chillmo/skatedb/user/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/chillmo/skatedb/user/dto/UpdateProfileRequest.java
@@ -1,0 +1,26 @@
+package com.chillmo.skatedb.user.dto;
+
+import com.chillmo.skatedb.user.domain.ExperienceLevel;
+import com.chillmo.skatedb.user.domain.Stand;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Payload for updating profile attributes of the currently authenticated user.
+ */
+@Data
+public class UpdateProfileRequest {
+
+    @Size(max = 255)
+    private String profilePictureUrl;
+
+    @Size(max = 500)
+    private String bio;
+
+    @Size(max = 100)
+    private String location;
+
+    private ExperienceLevel experienceLevel;
+
+    private Stand stand;
+}

--- a/src/main/java/com/chillmo/skatedb/user/dto/UpdateUserRolesRequest.java
+++ b/src/main/java/com/chillmo/skatedb/user/dto/UpdateUserRolesRequest.java
@@ -1,0 +1,17 @@
+package com.chillmo.skatedb.user.dto;
+
+import com.chillmo.skatedb.user.domain.Role;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.Set;
+
+/**
+ * Admin payload to change the roles assigned to a user.
+ */
+@Data
+public class UpdateUserRolesRequest {
+
+    @NotEmpty
+    private Set<Role> roles;
+}

--- a/src/main/java/com/chillmo/skatedb/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/chillmo/skatedb/user/dto/UserProfileResponse.java
@@ -1,0 +1,46 @@
+package com.chillmo.skatedb.user.dto;
+
+import com.chillmo.skatedb.user.domain.ExperienceLevel;
+import com.chillmo.skatedb.user.domain.Role;
+import com.chillmo.skatedb.user.domain.Stand;
+import com.chillmo.skatedb.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Response payload representing the public parts of a user's profile.
+ */
+public record UserProfileResponse(
+        Long id,
+        String username,
+        String email,
+        String profilePictureUrl,
+        String bio,
+        String location,
+        ExperienceLevel experienceLevel,
+        Stand stand,
+        Set<Role> roles,
+        LocalDateTime createdAt,
+        LocalDateTime lastLogin,
+        boolean enabled
+) {
+    public static UserProfileResponse from(User user) {
+        Set<Role> roles = user.getRoles() == null ? Collections.emptySet() : Set.copyOf(user.getRoles());
+        return new UserProfileResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getProfilePictureUrl(),
+                user.getBio(),
+                user.getLocation(),
+                user.getExperienceLevel(),
+                user.getStand(),
+                roles,
+                user.getCreatedAt(),
+                user.getLastLogin(),
+                Boolean.TRUE.equals(user.getEnabled())
+        );
+    }
+}

--- a/src/main/java/com/chillmo/skatedb/user/exception/InvalidPasswordException.java
+++ b/src/main/java/com/chillmo/skatedb/user/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.chillmo.skatedb.user.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException() {
+        super("Current password does not match");
+    }
+}

--- a/src/main/java/com/chillmo/skatedb/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/chillmo/skatedb/user/exception/UserNotFoundException.java
@@ -4,4 +4,8 @@ public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException(Long id) {
         super("User not found: " + id);
     }
+
+    public UserNotFoundException(String identifier) {
+        super("User not found: " + identifier);
+    }
 }

--- a/src/main/java/com/chillmo/skatedb/user/registration/exception/TokenNotFoundException.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/exception/TokenNotFoundException.java
@@ -9,6 +9,6 @@ public class TokenNotFoundException extends RuntimeException {
 
 
         public TokenNotFoundException(String token) {
-            super("Token not found: " + token);
+            super("Token not found or already used: " + token);
         }
     }

--- a/src/main/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenService.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenService.java
@@ -107,6 +107,7 @@ public class ConfirmationTokenService {
         var user = confirmationToken.getUser();
         user.setEnabled(true);
         userRepository.save(user);
+        tokenRepository.delete(confirmationToken);
         return true;
     }
 }

--- a/src/main/java/com/chillmo/skatedb/user/service/UserService.java
+++ b/src/main/java/com/chillmo/skatedb/user/service/UserService.java
@@ -1,17 +1,20 @@
 package com.chillmo.skatedb.user.service;
 import com.chillmo.skatedb.user.domain.User;
+import com.chillmo.skatedb.user.dto.ChangePasswordRequest;
+import com.chillmo.skatedb.user.dto.UpdateProfileRequest;
+import com.chillmo.skatedb.user.dto.UpdateUserRolesRequest;
 import com.chillmo.skatedb.user.email.service.EmailService;
-import com.chillmo.skatedb.user.registration.domain.ConfirmationToken;
-import com.chillmo.skatedb.user.registration.dto.UserRegistrationDto;
+import com.chillmo.skatedb.user.exception.InvalidPasswordException;
+import com.chillmo.skatedb.user.exception.UserNotFoundException;
 import com.chillmo.skatedb.user.registration.service.ConfirmationTokenRepository;
 import com.chillmo.skatedb.user.registration.service.ConfirmationTokenService;
 import com.chillmo.skatedb.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 public class UserService {
@@ -39,6 +42,7 @@ public class UserService {
      *
      * @return list of users
      */
+    @Transactional(readOnly = true)
     public java.util.List<User> getAllUsers() {
         return userRepository.findAll();
     }
@@ -49,11 +53,67 @@ public class UserService {
      * @param id user id
      * @return the updated user
      */
-    @org.springframework.transaction.annotation.Transactional
     public User enableUser(Long id) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new com.chillmo.skatedb.user.exception.UserNotFoundException(id));
+                .orElseThrow(() -> new UserNotFoundException(id));
         user.setEnabled(true);
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public User getByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException(username));
+    }
+
+    @Transactional
+    public User updateProfile(String username, UpdateProfileRequest request) {
+        User user = getByUsername(username);
+
+        if (request.getProfilePictureUrl() != null) {
+            user.setProfilePictureUrl(request.getProfilePictureUrl());
+        }
+        if (request.getBio() != null) {
+            user.setBio(request.getBio());
+        }
+        if (request.getLocation() != null) {
+            user.setLocation(request.getLocation());
+        }
+        if (request.getExperienceLevel() != null) {
+            user.setExperienceLevel(request.getExperienceLevel());
+        }
+        if (request.getStand() != null) {
+            user.setStand(request.getStand());
+        }
+
+        return userRepository.save(user);
+    }
+
+    @Transactional
+    public void changePassword(String username, ChangePasswordRequest request) {
+        User user = getByUsername(username);
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void deleteAccount(String username) {
+        User user = getByUsername(username);
+        userRepository.delete(user);
+    }
+
+    @Transactional
+    public User updateUserRoles(Long id, UpdateUserRolesRequest request) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+
+        Set<com.chillmo.skatedb.user.domain.Role> roles = request.getRoles();
+        user.setRoles(roles == null ? new HashSet<>() : new HashSet<>(roles));
         return userRepository.save(user);
     }
 }

--- a/src/test/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenServiceTest.java
+++ b/src/test/java/com/chillmo/skatedb/user/registration/service/ConfirmationTokenServiceTest.java
@@ -1,0 +1,84 @@
+package com.chillmo.skatedb.user.registration.service;
+
+import com.chillmo.skatedb.user.domain.User;
+import com.chillmo.skatedb.user.registration.domain.ConfirmationToken;
+import com.chillmo.skatedb.user.registration.exception.TokenExpiredException;
+import com.chillmo.skatedb.user.registration.exception.TokenNotFoundException;
+import com.chillmo.skatedb.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmationTokenServiceTest {
+
+    @Mock
+    private ConfirmationTokenRepository tokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ConfirmationTokenService confirmationTokenService;
+
+    @Test
+    void confirmTokenDeletesTokenAfterSuccessfulVerification() {
+        var user = new User();
+        user.setEnabled(false);
+
+        var confirmationToken = ConfirmationToken.builder()
+                .token("valid-token")
+                .createdAt(LocalDateTime.now().minusMinutes(1))
+                .expiresAt(LocalDateTime.now().plusMinutes(15))
+                .user(user)
+                .build();
+
+        when(tokenRepository.findByToken("valid-token")).thenReturn(Optional.of(confirmationToken));
+
+        boolean result = confirmationTokenService.confirmToken("valid-token");
+
+        assertTrue(result);
+        assertTrue(user.getEnabled());
+        verify(userRepository).save(user);
+        verify(tokenRepository).delete(confirmationToken);
+    }
+
+    @Test
+    void confirmTokenThrowsWhenTokenMissing() {
+        when(tokenRepository.findByToken("missing-token")).thenReturn(Optional.empty());
+
+        assertThrows(TokenNotFoundException.class, () -> confirmationTokenService.confirmToken("missing-token"));
+
+        verify(tokenRepository).findByToken("missing-token");
+        verifyNoMoreInteractions(tokenRepository);
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    void confirmTokenThrowsWhenTokenExpired() {
+        var user = new User();
+        var confirmationToken = ConfirmationToken.builder()
+                .token("expired-token")
+                .createdAt(LocalDateTime.now().minusHours(2))
+                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                .user(user)
+                .build();
+
+        when(tokenRepository.findByToken("expired-token")).thenReturn(Optional.of(confirmationToken));
+
+        assertThrows(TokenExpiredException.class, () -> confirmationTokenService.confirmToken("expired-token"));
+
+        verify(tokenRepository).findByToken("expired-token");
+        verify(tokenRepository, never()).delete(any());
+        verifyNoInteractions(userRepository);
+    }
+}

--- a/src/test/java/com/chillmo/skatedb/user/service/UserServiceTest.java
+++ b/src/test/java/com/chillmo/skatedb/user/service/UserServiceTest.java
@@ -1,0 +1,183 @@
+package com.chillmo.skatedb.user.service;
+
+import com.chillmo.skatedb.user.domain.ExperienceLevel;
+import com.chillmo.skatedb.user.domain.Role;
+import com.chillmo.skatedb.user.domain.Stand;
+import com.chillmo.skatedb.user.domain.User;
+import com.chillmo.skatedb.user.dto.ChangePasswordRequest;
+import com.chillmo.skatedb.user.dto.UpdateProfileRequest;
+import com.chillmo.skatedb.user.dto.UpdateUserRolesRequest;
+import com.chillmo.skatedb.user.email.service.EmailService;
+import com.chillmo.skatedb.user.exception.InvalidPasswordException;
+import com.chillmo.skatedb.user.exception.UserNotFoundException;
+import com.chillmo.skatedb.user.registration.service.ConfirmationTokenRepository;
+import com.chillmo.skatedb.user.registration.service.ConfirmationTokenService;
+import com.chillmo.skatedb.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ConfirmationTokenRepository tokenRepository;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private ConfirmationTokenService confirmationTokenService;
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(userRepository, tokenRepository, emailService, passwordEncoder, confirmationTokenService);
+    }
+
+    @Test
+    void updateProfileUpdatesProvidedFields() {
+        User user = User.builder()
+                .id(1L)
+                .username("skater")
+                .bio("old bio")
+                .location("Munich")
+                .experienceLevel(ExperienceLevel.NOVICE)
+                .stand(Stand.Regular)
+                .build();
+
+        UpdateProfileRequest request = new UpdateProfileRequest();
+        request.setBio("new bio");
+        request.setLocation("Berlin");
+        request.setExperienceLevel(ExperienceLevel.PRO);
+        request.setStand(Stand.Goofy);
+        request.setProfilePictureUrl("https://example.com/avatar.png");
+
+        when(userRepository.findByUsername("skater")).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+
+        User updated = userService.updateProfile("skater", request);
+
+        assertThat(updated.getBio()).isEqualTo("new bio");
+        assertThat(updated.getLocation()).isEqualTo("Berlin");
+        assertThat(updated.getExperienceLevel()).isEqualTo(ExperienceLevel.PRO);
+        assertThat(updated.getStand()).isEqualTo(Stand.Goofy);
+        assertThat(updated.getProfilePictureUrl()).isEqualTo("https://example.com/avatar.png");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateProfileThrowsWhenUserMissing() {
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+        UpdateProfileRequest request = new UpdateProfileRequest();
+        assertThrows(UserNotFoundException.class, () -> userService.updateProfile("unknown", request));
+    }
+
+    @Test
+    void changePasswordUpdatesWhenCurrentMatches() {
+        User user = User.builder()
+                .id(2L)
+                .username("skater")
+                .password("encoded-old")
+                .build();
+
+        ChangePasswordRequest request = new ChangePasswordRequest();
+        request.setCurrentPassword("oldPass123");
+        request.setNewPassword("newPass123");
+
+        when(userRepository.findByUsername("skater")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("oldPass123", "encoded-old")).thenReturn(true);
+        when(passwordEncoder.encode("newPass123")).thenReturn("encoded-new");
+
+        userService.changePassword("skater", request);
+
+        assertThat(user.getPassword()).isEqualTo("encoded-new");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void changePasswordRejectsInvalidCurrentPassword() {
+        User user = User.builder()
+                .id(2L)
+                .username("skater")
+                .password("encoded-old")
+                .build();
+
+        ChangePasswordRequest request = new ChangePasswordRequest();
+        request.setCurrentPassword("wrong");
+        request.setNewPassword("newPass123");
+
+        when(userRepository.findByUsername("skater")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", "encoded-old")).thenReturn(false);
+
+        assertThrows(InvalidPasswordException.class, () -> userService.changePassword("skater", request));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void deleteAccountRemovesUser() {
+        User user = User.builder()
+                .id(3L)
+                .username("skater")
+                .build();
+
+        when(userRepository.findByUsername("skater")).thenReturn(Optional.of(user));
+
+        userService.deleteAccount("skater");
+
+        verify(userRepository).delete(user);
+    }
+
+    @Test
+    void deleteAccountThrowsWhenUserMissing() {
+        when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.deleteAccount("missing"));
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    void updateRolesReplacesExistingRoles() {
+        User user = User.builder()
+                .id(4L)
+                .username("skater")
+                .roles(Set.of(Role.ROLE_USER))
+                .build();
+
+        UpdateUserRolesRequest request = new UpdateUserRolesRequest();
+        request.setRoles(Set.of(Role.ROLE_ADMIN));
+
+        when(userRepository.findById(4L)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+
+        User updated = userService.updateUserRoles(4L, request);
+
+        assertThat(updated.getRoles()).containsExactlyInAnyOrder(Role.ROLE_ADMIN);
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void updateRolesThrowsWhenUserMissing() {
+        UpdateUserRolesRequest request = new UpdateUserRolesRequest();
+        request.setRoles(Set.of(Role.ROLE_ADMIN));
+
+        when(userRepository.findById(7L)).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.updateUserRoles(7L, request));
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs and service logic that cover profile updates, password changes, account deletion, and admin-only role management
- secure the user API by tightening `/api/users` access and exposing self-service profile endpoints plus admin role updates
- add unit tests for the new user service flows

## Testing
- `./mvnw test` *(fails: unable to download Maven wrapper dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca22d4bfd483309764ed05a01fb1cd