### PR TITLE
Support email-based authentication lookup

### DIFF
--- a/src/main/java/com/chillmo/skatedb/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/chillmo/skatedb/user/service/CustomUserDetailsService.java
@@ -20,9 +20,9 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("Benutzer nicht gefunden: " + username));
+    public UserDetails loadUserByUsername(String identifier) throws UsernameNotFoundException {
+        User user = userRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new UsernameNotFoundException("Benutzer nicht gefunden: " + identifier));
         return new CustomUserDetails(user);
     }
 }

--- a/src/test/java/com/chillmo/skatedb/user/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/chillmo/skatedb/user/service/CustomUserDetailsServiceTest.java
@@ -1,0 +1,78 @@
+package com.chillmo.skatedb.user.service;
+
+import com.chillmo.skatedb.user.domain.CustomUserDetails;
+import com.chillmo.skatedb.user.domain.User;
+import com.chillmo.skatedb.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private CustomUserDetailsService customUserDetailsService;
+
+    @BeforeEach
+    void setUp() {
+        customUserDetailsService = new CustomUserDetailsService(userRepository);
+    }
+
+    @Test
+    void loadUserByUsernameSupportsUsernames() {
+        User user = User.builder()
+                .id(1L)
+                .username("skater")
+                .email("skater@example.com")
+                .password("encoded")
+                .build();
+
+        when(userRepository.findByIdentifier("skater")).thenReturn(Optional.of(user));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("skater");
+
+        assertThat(userDetails).isInstanceOf(CustomUserDetails.class);
+        assertThat(userDetails.getUsername()).isEqualTo("skater");
+        verify(userRepository).findByIdentifier("skater");
+    }
+
+    @Test
+    void loadUserByUsernameSupportsEmailAddresses() {
+        User user = User.builder()
+                .id(2L)
+                .username("skater")
+                .email("skater@example.com")
+                .password("encoded")
+                .build();
+
+        when(userRepository.findByIdentifier("skater@example.com")).thenReturn(Optional.of(user));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("skater@example.com");
+
+        assertThat(userDetails).isInstanceOf(CustomUserDetails.class);
+        assertThat(userDetails.getUsername()).isEqualTo("skater");
+        verify(userRepository).findByIdentifier("skater@example.com");
+    }
+
+    @Test
+    void loadUserByUsernameThrowsWhenUserMissing() {
+        when(userRepository.findByIdentifier("missing@example.com")).thenReturn(Optional.empty());
+
+        assertThrows(UsernameNotFoundException.class,
+                () -> customUserDetailsService.loadUserByUsername("missing@example.com"));
+        verify(userRepository).findByIdentifier("missing@example.com");
+    }
+}


### PR DESCRIPTION
## Summary
- resolve user lookup in `CustomUserDetailsService` through `UserRepository.findByIdentifier(...)` so both usernames and email addresses authenticate
- add unit coverage for username, email, and missing user lookups in the custom user details service

## Testing
- `./mvnw test` *(fails: unable to download Maven distribution in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb81bf7d048330b0cb707eb7267547