### PR TITLE
Document user self-service endpoints

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -15,10 +15,15 @@ This document lists the available REST endpoints provided by the SkateDB applica
 
 ### User Management
 
-| Method | Path | Description |
-| ------ | ---- | ----------- |
-| `GET` | `/api/users` | List all registered users. |
-| `PUT` | `/api/users/{id}/enable` | Enable a user account. |
+| Method | Path | Description | Authorization |
+| ------ | ---- | ----------- | -------------- |
+| `GET` | `/api/users` | List all registered users. | `ROLE_ADMIN` |
+| `GET` | `/api/users/me` | Retrieve the authenticated user's profile. | Authenticated user |
+| `PUT` | `/api/users/me` | Update the authenticated user's profile details. | Authenticated user |
+| `PUT` | `/api/users/me/password` | Change the authenticated user's password. | Authenticated user |
+| `DELETE` | `/api/users/me` | Permanently delete the authenticated user's account. | Authenticated user |
+| `PUT` | `/api/users/{id}/enable` | Enable a user account. | `ROLE_ADMIN` |
+| `PUT` | `/api/users/{id}/roles` | Replace the set of roles assigned to a user. | `ROLE_ADMIN` |
 
 ### Email
 


### PR DESCRIPTION
## Summary
- document the authenticated user profile, password, and deletion routes in the API reference
- add authorization details for every user management route
- include the admin-only roles update endpoint in the documentation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cb86151f1483308ac2971803bba259