### PR TITLE
Simplify UserService dependencies

### DIFF
--- a/src/main/java/com/chillmo/skatedb/user/service/UserService.java
+++ b/src/main/java/com/chillmo/skatedb/user/service/UserService.java
@@ -3,11 +3,8 @@ import com.chillmo.skatedb.user.domain.User;
 import com.chillmo.skatedb.user.dto.ChangePasswordRequest;
 import com.chillmo.skatedb.user.dto.UpdateProfileRequest;
 import com.chillmo.skatedb.user.dto.UpdateUserRolesRequest;
-import com.chillmo.skatedb.user.email.service.EmailService;
 import com.chillmo.skatedb.user.exception.InvalidPasswordException;
 import com.chillmo.skatedb.user.exception.UserNotFoundException;
-import com.chillmo.skatedb.user.registration.service.ConfirmationTokenRepository;
-import com.chillmo.skatedb.user.registration.service.ConfirmationTokenService;
 import com.chillmo.skatedb.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,21 +17,12 @@ import java.util.Set;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final ConfirmationTokenRepository tokenRepository;
-    private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
 
-    private final ConfirmationTokenService confirmationTokenService;
-
     public UserService(UserRepository userRepository,
-                       ConfirmationTokenRepository tokenRepository,
-                       EmailService emailService,
-                       PasswordEncoder passwordEncoder, ConfirmationTokenService confirmationTokenService) {
+                       PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
-        this.tokenRepository = tokenRepository;
-        this.emailService = emailService;
         this.passwordEncoder = passwordEncoder;
-        this.confirmationTokenService = confirmationTokenService;
     }
 
     /**

--- a/src/test/java/com/chillmo/skatedb/user/service/UserServiceTest.java
+++ b/src/test/java/com/chillmo/skatedb/user/service/UserServiceTest.java
@@ -7,11 +7,8 @@ import com.chillmo.skatedb.user.domain.User;
 import com.chillmo.skatedb.user.dto.ChangePasswordRequest;
 import com.chillmo.skatedb.user.dto.UpdateProfileRequest;
 import com.chillmo.skatedb.user.dto.UpdateUserRolesRequest;
-import com.chillmo.skatedb.user.email.service.EmailService;
 import com.chillmo.skatedb.user.exception.InvalidPasswordException;
 import com.chillmo.skatedb.user.exception.UserNotFoundException;
-import com.chillmo.skatedb.user.registration.service.ConfirmationTokenRepository;
-import com.chillmo.skatedb.user.registration.service.ConfirmationTokenService;
 import com.chillmo.skatedb.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,19 +31,13 @@ class UserServiceTest {
     @Mock
     private UserRepository userRepository;
     @Mock
-    private ConfirmationTokenRepository tokenRepository;
-    @Mock
-    private EmailService emailService;
-    @Mock
     private PasswordEncoder passwordEncoder;
-    @Mock
-    private ConfirmationTokenService confirmationTokenService;
 
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository, tokenRepository, emailService, passwordEncoder, confirmationTokenService);
+        userService = new UserService(userRepository, passwordEncoder);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove unused email and confirmation token dependencies from UserService
- update UserServiceTest to reflect the simplified constructor and mocks

## Testing
- `./mvnw -q -Dtest=UserServiceTest test` *(fails: unable to download Maven distribution in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb86cb24408330a5ae089afd565c4e