### PR TITLE
Validate email domains before sending

### DIFF
--- a/src/main/java/com/chillmo/skatedb/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chillmo/skatedb/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.chillmo.skatedb.exception;
 
 import com.chillmo.skatedb.dto.ErrorResponse;
+import com.chillmo.skatedb.user.email.exception.InvalidEmailDomainException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -30,6 +31,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex) {
         return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(InvalidEmailDomainException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidEmailDomain(InvalidEmailDomainException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/chillmo/skatedb/user/email/exception/InvalidEmailDomainException.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/exception/InvalidEmailDomainException.java
@@ -1,0 +1,32 @@
+package com.chillmo.skatedb.user.email.exception;
+
+public class InvalidEmailDomainException extends RuntimeException {
+
+    private final String email;
+    private final String domain;
+
+    public InvalidEmailDomainException(String email) {
+        this(email, null);
+    }
+
+    public InvalidEmailDomainException(String email, String domain) {
+        super(buildMessage(email, domain));
+        this.email = email;
+        this.domain = domain;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    private static String buildMessage(String email, String domain) {
+        if (domain == null || domain.isBlank()) {
+            return "The e-mail address '" + email + "' is not valid or cannot receive mail.";
+        }
+        return "The e-mail domain '" + domain + "' cannot receive mail (address: " + email + ").";
+    }
+}

--- a/src/main/java/com/chillmo/skatedb/user/email/service/EmailDomainValidator.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/service/EmailDomainValidator.java
@@ -1,0 +1,88 @@
+package com.chillmo.skatedb.user.email.service;
+
+import com.chillmo.skatedb.user.email.exception.InvalidEmailDomainException;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import java.util.Hashtable;
+import java.util.Locale;
+
+@Component
+public class EmailDomainValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmailDomainValidator.class);
+
+    /**
+     * Validates that the given e-mail address resolves to a domain that can receive mail.
+     *
+     * @param email address to validate
+     * @throws InvalidEmailDomainException if the address is empty, malformed or the domain lacks MX/A/AAAA records
+     */
+    public void validateOrThrow(String email) {
+        if (email == null || email.isBlank()) {
+            logger.warn("Skipping e-mail send because the address is blank");
+            throw new InvalidEmailDomainException(email);
+        }
+
+        String domain = extractDomain(email);
+        if (domain == null || domain.isBlank()) {
+            logger.warn("Skipping e-mail send because the address '{}' is not a valid e-mail", email);
+            throw new InvalidEmailDomainException(email);
+        }
+
+        if (!hasValidDnsRecords(domain)) {
+            logger.warn(
+                    "Skipping e-mail send because the domain '{}' (address: {}) exposes no MX or A/AAAA records",
+                    domain,
+                    email
+            );
+            throw new InvalidEmailDomainException(email, domain);
+        }
+    }
+
+    private String extractDomain(String email) {
+        try {
+            InternetAddress address = new InternetAddress(email);
+            address.validate();
+            String normalized = address.getAddress();
+            int atIndex = normalized.lastIndexOf('@');
+            if (atIndex < 0 || atIndex == normalized.length() - 1) {
+                return null;
+            }
+            return normalized.substring(atIndex + 1).toLowerCase(Locale.ROOT);
+        } catch (AddressException ex) {
+            logger.debug("Invalid e-mail syntax for '{}': {}", email, ex.getMessage());
+            return null;
+        }
+    }
+
+    private boolean hasValidDnsRecords(String domain) {
+        Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+
+        try (DirContext ctx = new InitialDirContext(env)) {
+            Attributes attributes = ctx.getAttributes(domain, new String[]{"MX", "A", "AAAA"});
+            return hasEntries(attributes, "MX") || hasEntries(attributes, "A") || hasEntries(attributes, "AAAA");
+        } catch (NamingException ex) {
+            logger.debug("DNS lookup failed for domain '{}': {}", domain, ex.getMessage());
+            return false;
+        }
+    }
+
+    private boolean hasEntries(Attributes attributes, String key) {
+        if (attributes == null) {
+            return false;
+        }
+        Attribute attribute = attributes.get(key);
+        return attribute != null && attribute.size() > 0;
+    }
+}

--- a/src/main/java/com/chillmo/skatedb/user/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/chillmo/skatedb/user/email/service/EmailServiceImpl.java
@@ -1,10 +1,12 @@
 package com.chillmo.skatedb.user.email.service;
 
+import com.chillmo.skatedb.user.email.exception.InvalidEmailDomainException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -15,13 +17,18 @@ public class EmailServiceImpl implements EmailService {
 
     private static final Logger logger = LoggerFactory.getLogger(EmailServiceImpl.class);
 
-    @Value("${spring.mail.username}")
-    private String mailFrom;
-
     private final JavaMailSender mailSender;
+    private final String mailFrom;
+    private final EmailDomainValidator emailDomainValidator;
 
-    public EmailServiceImpl(JavaMailSender mailSender) {
+    public EmailServiceImpl(
+            JavaMailSender mailSender,
+            @Value("${spring.mail.username}") String mailFrom,
+            EmailDomainValidator emailDomainValidator
+    ) {
         this.mailSender = mailSender;
+        this.mailFrom = mailFrom;
+        this.emailDomainValidator = emailDomainValidator;
     }
 
     @Override
@@ -29,6 +36,8 @@ public class EmailServiceImpl implements EmailService {
      * {@inheritDoc}
      */
     public void send(String to, String subject, String body) {
+        emailDomainValidator.validateOrThrow(to);
+
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper =
@@ -39,10 +48,12 @@ public class EmailServiceImpl implements EmailService {
             helper.setText(body, true);
             mailSender.send(message);
             logger.info("Email successfully sent to: {}", to);
+        } catch (MailException e) {
+            logger.error("Mail server rejected email to: {}", to, e);
+            throw new IllegalStateException("Error sending e-mail to " + to, e);
         } catch (MessagingException e) {
             logger.error("Error sending email to: {}", to, e);
-            throw new IllegalStateException(
-                    "Error sending e-mail to " + to, e);
+            throw new IllegalStateException("Error sending e-mail to " + to, e);
         }
     }
 
@@ -52,6 +63,16 @@ public class EmailServiceImpl implements EmailService {
      * {@inheritDoc}
      */
     public void sendAsync(String to, String subject, String body) {
-        send(to, subject, body);
+        try {
+            send(to, subject, body);
+        } catch (InvalidEmailDomainException ex) {
+            logger.warn(
+                    "Skipping async e-mail because the domain is not deliverable: {} - {}",
+                    to,
+                    ex.getMessage()
+            );
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected error while sending async e-mail to: {}", to, ex);
+        }
     }
 }

--- a/src/main/java/com/chillmo/skatedb/user/registration/exception/RegistrationExceptionHandler.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/exception/RegistrationExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.chillmo.skatedb.user.registration.exception;
 
 import com.chillmo.skatedb.dto.ErrorResponse;
+import com.chillmo.skatedb.user.email.exception.InvalidEmailDomainException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +35,16 @@ public class RegistrationExceptionHandler {
 
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<ErrorResponse> handleInvalidPassword(InvalidPasswordException ex) {
+        ErrorResponse err = new ErrorResponse(
+                ex.getMessage(),
+                HttpStatus.BAD_REQUEST.value(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.badRequest().body(err);
+    }
+
+    @ExceptionHandler(InvalidEmailDomainException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidEmailDomain(InvalidEmailDomainException ex) {
         ErrorResponse err = new ErrorResponse(
                 ex.getMessage(),
                 HttpStatus.BAD_REQUEST.value(),

--- a/src/main/java/com/chillmo/skatedb/user/registration/service/UserRegistrationService.java
+++ b/src/main/java/com/chillmo/skatedb/user/registration/service/UserRegistrationService.java
@@ -1,6 +1,7 @@
 package com.chillmo.skatedb.user.registration.service;
 
 import com.chillmo.skatedb.user.domain.User;
+import com.chillmo.skatedb.user.email.service.EmailDomainValidator;
 import com.chillmo.skatedb.user.email.service.EmailService;
 import com.chillmo.skatedb.user.registration.domain.ConfirmationToken;
 import com.chillmo.skatedb.user.registration.dto.UserRegistrationDto;
@@ -20,6 +21,7 @@ public class UserRegistrationService {
     private final ConfirmationTokenService confirmationTokenService;
     private final PasswordValidationService passwordValidationService;
     private final EmailRegisterService emailRegisterService;
+    private final EmailDomainValidator emailDomainValidator;
 
     public UserRegistrationService(
             UserRepository userRepository,
@@ -27,7 +29,8 @@ public class UserRegistrationService {
             PasswordEncoder passwordEncoder,
             ConfirmationTokenService confirmationTokenService,
             PasswordValidationService passwordValidationService,
-            EmailRegisterService emailRegisterService
+            EmailRegisterService emailRegisterService,
+            EmailDomainValidator emailDomainValidator
     ) {
         this.userRepository = userRepository;
         this.emailService = emailService;
@@ -35,6 +38,7 @@ public class UserRegistrationService {
         this.confirmationTokenService = confirmationTokenService;
         this.passwordValidationService = passwordValidationService;
         this.emailRegisterService = emailRegisterService;
+        this.emailDomainValidator = emailDomainValidator;
     }
 
     @Transactional
@@ -46,6 +50,8 @@ public class UserRegistrationService {
         if (userRepository.existsByEmail(dto.getEmail())) {
             throw new EmailAlreadyExistsException(dto.getEmail());
         }
+
+        emailDomainValidator.validateOrThrow(dto.getEmail());
 
         // 2) Passwort-Policy prüfen
         passwordValidationService.validate(dto.getPassword());

--- a/src/test/java/com/chillmo/skatedb/user/email/service/EmailServiceImplTest.java
+++ b/src/test/java/com/chillmo/skatedb/user/email/service/EmailServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.chillmo.skatedb.user.email.service;
+
+import com.chillmo.skatedb.user.email.exception.InvalidEmailDomainException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceImplTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private EmailDomainValidator emailDomainValidator;
+
+    private EmailServiceImpl emailService;
+
+    @BeforeEach
+    void setUp() {
+        emailService = new EmailServiceImpl(mailSender, "no-reply@skatedb.test", emailDomainValidator);
+    }
+
+    @Test
+    void send_whenDomainIsValid_dispatchesMail() throws Exception {
+        doNothing().when(emailDomainValidator).validateOrThrow("user@example.com");
+
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        emailService.send("user@example.com", "Subject", "<p>Body</p>");
+
+        verify(mailSender).send(mimeMessage);
+    }
+
+    @Test
+    void send_whenDomainIsInvalid_throwsExceptionAndSkipsSend() {
+        doThrow(new InvalidEmailDomainException("user@invalid.test"))
+                .when(emailDomainValidator)
+                .validateOrThrow("user@invalid.test");
+
+        assertThatThrownBy(() -> emailService.send("user@invalid.test", "Subject", "<p>Body</p>"))
+                .isInstanceOf(InvalidEmailDomainException.class);
+
+        verify(mailSender, never()).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void send_whenMailSenderFails_wrapsInIllegalState() throws Exception {
+        doNothing().when(emailDomainValidator).validateOrThrow("user@example.com");
+
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doThrow(new MailSendException("smtp error")).when(mailSender).send(mimeMessage);
+
+        assertThatThrownBy(() -> emailService.send("user@example.com", "Subject", "<p>Body</p>"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasCauseInstanceOf(MailSendException.class);
+    }
+
+    @Test
+    void sendAsync_whenValidationFails_doesNotPropagateException() {
+        doThrow(new InvalidEmailDomainException("user@invalid.test"))
+                .when(emailDomainValidator)
+                .validateOrThrow("user@invalid.test");
+
+        assertThatCode(() -> emailService.sendAsync("user@invalid.test", "Subject", "<p>Body</p>"))
+                .doesNotThrowAnyException();
+
+        verify(mailSender, never()).send(any(MimeMessage.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add an `EmailDomainValidator` that performs DNS checks and raises a dedicated `InvalidEmailDomainException`
- guard registration and email delivery with the validator and improve async error handling/logging
- extend exception handling and add unit tests for the updated services

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d119683ab483309a6d58ae3ad4f289