### PR TITLE
Ensure template users start enabled

### DIFF
--- a/src/main/java/com/chillmo/skatedb/user/domain/User.java
+++ b/src/main/java/com/chillmo/skatedb/user/domain/User.java
@@ -83,7 +83,9 @@ public class User {
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
-        this.enabled = false; // Standardmäßig deaktiviert bis Bestätigung
+        if (!this.enabled) {
+            this.enabled = false; // Standardmäßig deaktiviert bis Bestätigung, falls nicht explizit gesetzt
+        }
     }
 
     public Boolean getEnabled() {


### PR DESCRIPTION
## Summary
- prevent the user entity's pre-persist hook from overriding an explicitly enabled flag
- make the template data loader enable existing template users when seeding data

## Testing
- ./mvnw test *(fails: `wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip`)*

------
https://chatgpt.com/codex/tasks/task_e_68d12958e4788330908448d6eaf20d2d